### PR TITLE
Add tag to git branch information

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -848,15 +848,18 @@ _lp_git_branch()
 
     \git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
 
-    local branch
+    local branch tag
+    if tag="$(\git describe --exact-match --tags 2>/dev/null)"; then
+        tag="($tag)"
+    fi
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then
-        _lp_escape "${branch#refs/heads/}"
+        _lp_escape "${branch#refs/heads/}$tag"
     else
         # In detached head state, use commit instead
         # No escape needed
-        \git rev-parse --short -q HEAD
+        _lp_escape "$(\git rev-parse --short -q HEAD)$tag"
     fi
 }
 


### PR DESCRIPTION
Add tag information if exact matches current HEAD.

```
# show branch - HEAD has no tag
develop+* ± git co master
# show branch - HEAD has tag
master(rel14.3)+* 1 ± git co rel14.2
# detached tag
d46151ed(rel14.2)+* ± git co 9d899
# detached
9d899338+* ±
```